### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows/tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows/tag.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the tagging workflow from `actions/checkout@v4` to `actions/checkout@v6` to keep the repository’s automation current and supported.

### 📊 Key Changes
- ⬆️ Upgraded `.github/workflows/tag.yml` from `actions/checkout@v4` to `actions/checkout@v6`
- 🛠️ No other workflow logic was changed
- 🔖 The update affects the automated tag-related GitHub Actions job only

### 🎯 Purpose & Impact
- ✅ Keeps CI/CD automation aligned with the latest GitHub Action version
- 🔒 May improve security, compatibility, and long-term maintenance by using a newer supported action release
- 🚀 Helps reduce risk of future issues caused by outdated workflow dependencies
- 👥 No direct user-facing changes to assets or functionality, but it improves repository reliability behind the scenes