### PR TITLE
Bump actions/setup-python from v5 to v6 in /.github/workflows/tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -61,7 +61,7 @@ jobs:
           git push origin "${{ github.event.inputs.tag_name }}"
 
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Bump actions/setup-python from v5 to v6 in /.github/workflows/tag.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use `actions/setup-python@v6` instead of `@v5` in the repository’s tag automation process.

### 📊 Key Changes
- Upgraded the Python setup step in `.github/workflows/tag.yml` from `actions/setup-python@v5` to `actions/setup-python@v6`.
- No application code, assets, or tagging logic were changed—only the GitHub Actions dependency version was updated. 📦

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies up to date. ✅
- Helps ensure better compatibility, security, and long-term support for the repository’s CI/CD automation. 🔒
- Low risk change: users should not see any direct functional differences, but repository automation may be more reliable going forward. 🚀