### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions checkout step in the tagging workflow from `actions/checkout@v6` to `actions/checkout@v7` to keep repository automation current.

### 📊 Key Changes
- Upgraded the `actions/checkout` GitHub Action in `.github/workflows/tag.yml`
- Changed the workflow dependency from `actions/checkout@v6` to `actions/checkout@v7`
- No changes to application code, assets, or user-facing repository content

### 🎯 Purpose & Impact
- Keeps GitHub workflow automation aligned with the latest supported action version 🚀
- May improve reliability, security, and long-term maintainability of the tagging workflow 🔒
- Has little to no direct impact on end users, but helps ensure release/tag automation continues to run smoothly ⚙️