### PR TITLE
Add AGENTS.md agent guidance with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, etc.) when working with code in this repository. CLAUDE.md is a symlink to this file.
+
+## Core Principles (CRITICAL)
+
+Respecting these principles is critical for every PR.
+
+**Less is more. The simplest solution is the best solution.**
+
+The action hierarchy for every change: **Delete > Replace > Add**. The best code change is a deletion. The second best is modifying what exists. Adding new code is the last resort.
+
+1. **Minimal**: The simplest solution that works. Do not over-engineer, over-abstract, or add code just in case. Three similar lines beat a premature abstraction. Avoid error handling for impossible states, feature flags, compatibility shims, or policy scaffolding unless they are truly required.
+2. **Solve at the source**: Do not hack fixes. Solve problems at their root. If something is broken, fix or remove the broken thing. Never patch over a broken abstraction, add workarounds, or add synchronization code for state that should not be duplicated.
+3. **Delete ruthlessly**: When replacing code, delete what it replaced. Remove unused imports, functions, types, files, and commented-out code. Git preserves history. Run the repo's relevant dead-code or cleanup check when available.
+4. **Replace > Add**: Modify existing code over adding new code. Edit existing files, extend existing components or functions with minimal parameters, and reuse existing utilities. If creating a new file, first prove it cannot fit cleanly in an existing file.
+5. **Check existing**: Search the entire repo before creating anything new. If a feature, component, helper, responder, workflow, or utility already solves a similar problem, reuse or adapt it and delete the duplicate path.
+6. **Deduplicate**: Do not duplicate existing code when updating the repo. Consolidate or refactor duplicates you find when it is in scope and low risk.
+7. **Zero Regression**: Do not break existing features or workflows unless the PR intentionally removes them with evidence.
+8. **Production ready**: All changes must be thoroughly debugged, validated, and production ready.
+
+**When fixing bugs, ask: "What can I delete?" before "What can I replace?" before "What should I add?"**
+
+## PR Workflow
+
+After opening a PR:
+
+1. Wait for the automated PR review and auto-format commit from Ultralytics Actions (`format.yml`), then pull and address every finding.
+2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations — use the Codex CLI, one fresh `codex exec` run per round. Fix, push, and repeat until a fresh run reports LGTM.
+3. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never force-push, reset, or revert commits you did not author.
+4. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
+
+## Commands
+
+```bash
+# No build or test suite exists — this repository contains only static assets and Markdown
+npx prettier --write "**/*.md" "**/*.yml"  # format Markdown/YAML as CI does (format.yml, prettier: true)
+uv pip install codespell && codespell      # spell-check as CI does (format.yml, spelling: true)
+```
+
+CI is a single `ubuntu-latest` job (no matrix) in `.github/workflows/format.yml` running `ultralytics/actions@main` with `python: false` (no Python files) and `links: false`.
+
+## Architecture
+
+This repository hosts the shared static assets for the Ultralytics ecosystem — there is no source code. It serves two roles:
+
+- **Committed files on `main`** (logos, banners, docs images, social icons) are consumed by external sites and repos via `https://raw.githubusercontent.com/ultralytics/assets/main/...` URLs. Published paths are a stable public API: renaming, moving, or deleting a file breaks every external reference to it, so treat such changes as breaking.
+- **GitHub Releases** host the pretrained model weights (`.pt`) and dataset archives that Ultralytics libraries auto-download when a requested file is not found locally (e.g. release `v8.4.0` for YOLO26). These binaries live in release assets, never in the repo tree.
+
+Releases are cut manually via `.github/workflows/tag.yml` (`workflow_dispatch` only), hard-gated to `github.repository == 'ultralytics/assets' && github.actor == 'glenn-jocher'`; it pushes the tag and generates release notes with `ultralytics-actions-summarize-release`.
+
+## Conventions
+
+- Ultralytics Actions adds AGPL-3.0 license headers to workflow/YAML files automatically — don't add or revert them manually.
+- Prettier (Markdown/YAML/JSON/CSS) and codespell run on every PR via `format.yml`; expect an auto-format commit pushed to your branch.
+- `README.md` and `README.zh-CN.md` must stay in sync — apply any README change to both.
+- Release tags (e.g. `v8.4.0`) track `ultralytics` package minor versions; there is no version file in this repo to bump.
+- Binary assets are committed directly; prefer compressed formats already in use (`.avif` for docs images, `.svg` for logos).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ After opening a PR:
 
 ```bash
 # No build or test suite exists — this repository contains only static assets and Markdown
-npx prettier --write "**/*.md" "**/*.yml" # format Markdown/YAML as CI does (format.yml, prettier: true)
-uv pip install codespell && codespell     # spell-check as CI does (format.yml, spelling: true)
+npx prettier --write --print-width 120 "**/*.md" "**/*.yml" # approximates the prettier step in format.yml
+uvx codespell                                               # spell-check (format.yml, spelling: true)
 ```
 
-CI is a single `ubuntu-latest` job (no matrix) in `.github/workflows/format.yml` running `ultralytics/actions@main` with `python: false` (no Python files) and `links: false`.
+`.github/workflows/format.yml` is the formatting source of truth: a single `ubuntu-latest` job (no matrix) running `ultralytics/actions@main` with `python: false` (no Python files) and `links: false`. PRs also get a GitHub default-setup CodeQL check (no workflow file in the repo).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ After opening a PR:
 
 ```bash
 # No build or test suite exists — this repository contains only static assets and Markdown
-npx prettier --write "**/*.md" "**/*.yml"  # format Markdown/YAML as CI does (format.yml, prettier: true)
-uv pip install codespell && codespell      # spell-check as CI does (format.yml, spelling: true)
+npx prettier --write "**/*.md" "**/*.yml" # format Markdown/YAML as CI does (format.yml, prettier: true)
+uv pip install codespell && codespell     # spell-check as CI does (format.yml, spelling: true)
 ```
 
 CI is a single `ubuntu-latest` job (no matrix) in `.github/workflows/format.yml` running `ultralytics/actions@main` with `python: false` (no Python files) and `links: false`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Dataset artifacts are published through repository releases and referenced from 
 - `app/`: App store badges, screenshots, and onboarding visuals.
 - `blog/`, `og/`, and `partners/`: Blog, Open Graph, and partner media.
 - `docs/`: Documentation images, diagrams, screenshots, audio, and media.
+- `documents/`: Legal and policy documents such as the Contributor License Agreement (CLA).
 - `im/`: Sample images used in inference and documentation examples.
 - `logo/`: Ultralytics logos, logotypes, and favicon assets.
 - `mkdocs/`: Assets used by Ultralytics documentation builds.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,6 +53,7 @@ results = model("path/to/image.jpg")
 - `app/`：应用商店徽章、截图和引导页视觉资源。
 - `blog/`、`og/` 和 `partners/`：博客、Open Graph 和合作伙伴媒体资源。
 - `docs/`：文档图片、图表、截图、音频和媒体。
+- `documents/`：法律与政策文档，例如贡献者许可协议（CLA）。
 - `im/`：推理和文档示例使用的示例图片。
 - `logo/`：Ultralytics 标志、字标和网站图标资源。
 - `mkdocs/`：Ultralytics 文档构建使用的资源。


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` with guidance for AI coding agents working in this repository, with `CLAUDE.md` as a relative symlink to it.

- **AGENTS.md**: Core Principles, PR workflow, verified commands (prettier/codespell as run by `format.yml`), architecture notes (raw-URL asset serving on `main`, model weights via GitHub Releases, `tag.yml` release gating), and repo conventions.
- **README.md / README.zh-CN.md**: add the missing `documents/` entry (Contributor License Agreement) to the Repository Layout section in both READMEs.

No asset files are changed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds AI-agent contribution guidance and documents the new `documents/` asset directory for legal/policy files 📚

### 📊 Key Changes
- Added `AGENTS.md` with repository-specific guidance for AI coding agents like Claude Code 🤖
- Added `CLAUDE.md` as a symlink to `AGENTS.md` for Claude-compatible tooling 🔗
- Documented core contribution principles: keep changes minimal, prefer deletion/replacement over adding code, avoid duplication, and protect existing workflows ✅
- Added PR workflow instructions covering formatting, review, rebasing, and cleanup 🛠️
- Clarified repository architecture, including static asset usage and release-hosted model/dataset binaries 📦
- Updated both English and Chinese READMEs to include the new `documents/` directory for legal and policy documents 🌐

### 🎯 Purpose & Impact
- Helps AI agents and contributors work consistently with Ultralytics standards, reducing unnecessary complexity and regressions 🚀
- Improves maintainability by emphasizing simple, production-ready changes and careful handling of public asset paths 🧹
- Makes repository structure clearer for users browsing assets, especially legal documents like the Contributor License Agreement 📄
- Keeps multilingual documentation aligned, improving accessibility for both English and Chinese readers 🤝