### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -61,7 +61,7 @@ jobs:
           git push origin "${{ github.event.inputs.tag_name }}"
 
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions Python setup action to the latest major version for tag workflows. ⚙️

### 📊 Key Changes

- Upgrades `actions/setup-python` from `v6` to `v7` in `.github/workflows/tag.yml`.
- Keeps the workflow on the latest available Python 3.x version.
- No changes to the tagging or release process itself.

### 🎯 Purpose & Impact

- Improves CI/CD maintenance by using the newer official action version. ✅
- May provide updated runner compatibility, fixes, and performance improvements.
- Helps keep automated tag workflows aligned with current GitHub Actions best practices.