### PR TITLE
Enable requested PR reviews

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
+          token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI
           python: false # No Python files in this repository
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
           links: false # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
-          review: false # GitHub Actions cannot approve PRs
+          review: false # Review only when UltralyticsAssistant is requested
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main
         with:
-          token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated fallback
+          token: ${{ github.event.action == 'review_requested' && secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           labels: true # Auto-label issues/PRs using AI
           python: false # No Python files in this repository
           prettier: true # Format YAML, JSON, Markdown, CSS


### PR DESCRIPTION
## Summary
- use the existing UltralyticsAssistant token only for manually requested PR reviews
- preserve the default workflow token for formatting, labels, summaries, and every existing event
- keep automatic PR reviews disabled

Deleted: the default-token-only requested-review path and its obsolete claim that GitHub Actions cannot approve reviews. No new workflow or review implementation is added; this reuses `ultralytics/actions@main`.

## Validation
- live requested review on the initial head completed and was approved by UltralyticsAssistant
- `npx prettier --check .github/workflows/format.yml`
- `actionlint .github/workflows/format.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔐 Updated the formatting workflow to use an appropriate GitHub token when an AI review is requested.

### 📊 Key Changes

- Added conditional token selection for `review_requested` events:
  - Uses `secrets._GITHUB_TOKEN` when an `UltralyticsAssistant` review is requested.
  - Otherwise continues using the standard `GITHUB_TOKEN`.
- Clarified the review configuration comment to indicate that reviews run only when `UltralyticsAssistant` is requested.
- Preserved existing formatting, spelling, labeling, and AI summary checks.

### 🎯 Purpose & Impact

- ✅ Enables the workflow to support requested AI reviews with the required token permissions.
- 🤖 Keeps automated PR summaries and labeling functioning as before.
- 🛡️ Avoids unnecessary permission changes for standard workflow runs.
- 📦 No direct impact on repository users or assets; improvements are limited to GitHub Actions automation.